### PR TITLE
Maybe add definition for die size

### DIFF
--- a/text/rules.md
+++ b/text/rules.md
@@ -78,6 +78,9 @@ twice and take the lower result. If they are using a weapon that is especially
 well-crafted or well-suited for the attack they are making they roll twice and
 take the higher result.
 
+Some rules refer to a **die size**. The die size is the number of sides on
+the die. For example, a d6 has a die size of 6.
+
 ## Damage, Armor, And HP
 
 Living things in _Beyond_ have **HP** which indicates how much damage they can


### PR DESCRIPTION
If die size is going to be used for stuff it might make sense to define it with the other Dice rules. But it's probably more of a DM thing than a player thing so maybe it should be in a different section? Or maybe this is so obvious it's not worth including?